### PR TITLE
Update checkout action to v4

### DIFF
--- a/.github/workflows/argon2.yml
+++ b/.github/workflows/argon2.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout argon2
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: argon2
           repository: winlibs/argon2

--- a/.github/workflows/curl.yml
+++ b/.github/workflows/curl.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout curl
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: curl
           repository: winlibs/curl

--- a/.github/workflows/cyrus-sasl.yml
+++ b/.github/workflows/cyrus-sasl.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout cyrus-sasl
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: cyrus-sasl
           repository: winlibs/cyrus-sasl

--- a/.github/workflows/enchant.yml
+++ b/.github/workflows/enchant.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout enchant
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: enchant
           repository: winlibs/enchant

--- a/.github/workflows/freetype.yml
+++ b/.github/workflows/freetype.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout freetype
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: freetype
           repository: winlibs/freetype

--- a/.github/workflows/freetype_cmake.yml
+++ b/.github/workflows/freetype_cmake.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout freetype
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: freetype
           repository: winlibs/freetype

--- a/.github/workflows/gettext.yml
+++ b/.github/workflows/gettext.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout gettext
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: gettext
           repository: winlibs/gettext

--- a/.github/workflows/glib.yml
+++ b/.github/workflows/glib.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout glib
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: glib
           repository: winlibs/glib

--- a/.github/workflows/icu4c.yml
+++ b/.github/workflows/icu4c.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout icu4c
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: icu4c
           repository: winlibs/icu4c

--- a/.github/workflows/imagemagick.yml
+++ b/.github/workflows/imagemagick.yml
@@ -16,11 +16,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout imagemagick
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: imagemagick-windows
           repository: ImageMagick/ImageMagick-Windows.git

--- a/.github/workflows/imap.yml
+++ b/.github/workflows/imap.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout imap
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: imap
           repository: winlibs/imap

--- a/.github/workflows/libavif.yml
+++ b/.github/workflows/libavif.yml
@@ -22,11 +22,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout libavif
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: libavif
           repository: winlibs/libavif

--- a/.github/workflows/libffi.yml
+++ b/.github/workflows/libffi.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout libffi
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: libffi
           repository: winlibs/libffi

--- a/.github/workflows/libiconv.yml
+++ b/.github/workflows/libiconv.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout libiconv
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: libiconv
           repository: winlibs/libiconv

--- a/.github/workflows/libjpeg.yml
+++ b/.github/workflows/libjpeg.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout libjpeg
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: libjpeg
           repository: winlibs/libjpeg

--- a/.github/workflows/liblzma.yml
+++ b/.github/workflows/liblzma.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout liblzma
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: liblzma
           repository: winlibs/liblzma

--- a/.github/workflows/libmemcached.yml
+++ b/.github/workflows/libmemcached.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout libmemcached
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: libmemcached
           repository: awesomized/libmemcached

--- a/.github/workflows/libpng.yml
+++ b/.github/workflows/libpng.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout libpng
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: libpng
           repository: winlibs/libpng

--- a/.github/workflows/librdkafka.yml
+++ b/.github/workflows/librdkafka.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout librdkafka
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: librdkafka
           repository: edenhill/librdkafka

--- a/.github/workflows/libsodium.yml
+++ b/.github/workflows/libsodium.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout libsodium
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: libsodium
           repository: winlibs/libsodium

--- a/.github/workflows/libssh2.yml
+++ b/.github/workflows/libssh2.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout libssh2
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: libssh2
           repository: winlibs/libssh2

--- a/.github/workflows/libssh2_msbuild.yml
+++ b/.github/workflows/libssh2_msbuild.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout libssh2
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: libssh2
           repository: winlibs/libssh2

--- a/.github/workflows/libtidy.yml
+++ b/.github/workflows/libtidy.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout libtidy
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: libtidy
           repository: winlibs/libtidy

--- a/.github/workflows/libwebp.yml
+++ b/.github/workflows/libwebp.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout libwebp
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: libwebp
           repository: winlibs/libwebp

--- a/.github/workflows/libxml2.yml
+++ b/.github/workflows/libxml2.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout libxml2
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: libxml2
           repository: winlibs/libxml2

--- a/.github/workflows/libxpm.yml
+++ b/.github/workflows/libxpm.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout libxpm
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: libxpm
           repository: winlibs/libxpm

--- a/.github/workflows/libxslt.yml
+++ b/.github/workflows/libxslt.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout libxslt
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: libxslt
           repository: winlibs/libxslt

--- a/.github/workflows/libzip.yml
+++ b/.github/workflows/libzip.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout libzip
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: libzip
           repository: winlibs/libzip

--- a/.github/workflows/libzstd.yml
+++ b/.github/workflows/libzstd.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout libzstd
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: libzstd
           repository: facebook/zstd

--- a/.github/workflows/lmdb.yml
+++ b/.github/workflows/lmdb.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout lmdb
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: lmdb
           repository: winlibs/lmdb

--- a/.github/workflows/mpir.yml
+++ b/.github/workflows/mpir.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout mpir
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: mpir
           repository: winlibs/mpir

--- a/.github/workflows/net-snmp.yml
+++ b/.github/workflows/net-snmp.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout net-snmp
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: net-snmp
           repository: winlibs/net-snmp

--- a/.github/workflows/nghttp2.yml
+++ b/.github/workflows/nghttp2.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout nghttp2
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: nghttp2
           repository: winlibs/nghttp2

--- a/.github/workflows/oniguruma.yml
+++ b/.github/workflows/oniguruma.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout oniguruma
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: oniguruma
           repository: winlibs/oniguruma

--- a/.github/workflows/openldap.yml
+++ b/.github/workflows/openldap.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout openldap
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: openldap
           repository: winlibs/openldap

--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout openssl
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: openssl
           repository: winlibs/openssl

--- a/.github/workflows/postgresql.yml
+++ b/.github/workflows/postgresql.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout postgresql
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: postgresql
           repository: winlibs/postgresql

--- a/.github/workflows/pslib.yml
+++ b/.github/workflows/pslib.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout pslib
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: pslib
           repository: winlibs/pslib

--- a/.github/workflows/pthreads.yml
+++ b/.github/workflows/pthreads.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout pthreads
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: pthreads
           repository: winlibs/pthreads

--- a/.github/workflows/qdbm.yml
+++ b/.github/workflows/qdbm.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout qdbm
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: qdbm
           repository: winlibs/qdbm

--- a/.github/workflows/sqlite3.yml
+++ b/.github/workflows/sqlite3.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout sqlite3
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: sqlite3
           repository: winlibs/sqlite3

--- a/.github/workflows/wineditline.yml
+++ b/.github/workflows/wineditline.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout wineditline
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: wineditline
           repository: winlibs/wineditline

--- a/.github/workflows/zlib.yml
+++ b/.github/workflows/zlib.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout winlib-builder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: winlib-builder
       - name: Checkout zlib
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: zlib
           repository: winlibs/zlib


### PR DESCRIPTION
`actions/checkout@v3` is deprecated, so we update to v4.  This is done without further tests, but a mere search and replace.  We do not expect anything to break, but even if so, we can still fix these issues.

---

cc @shivammathur 