### PR TITLE
Update to microsoft/setup-msbuild v2

### DIFF
--- a/.github/workflows/cyrus-sasl.yml
+++ b/.github/workflows/cyrus-sasl.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Fetch dependencies
         run: powershell winlib-builder/scripts/fetch-deps -lib cyrus-sasl -version ${{github.event.inputs.php}} -vs ${{steps.virtuals.outputs.vs}} -arch ${{matrix.arch}} -stability ${{github.event.inputs.stability}}
       - name: Setup msbuild
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v2
       - name: Build cyrus-sasl-core
         run: cd cyrus-sasl\win32 && msbuild /p:Configuration=Release;Platform=${{matrix.arch}};PlatformToolset=${{steps.virtuals.outputs.msts}};WindowsTargetPlatformVersion=${{steps.virtuals.outputs.winsdk}} cyrus-sasl-core.sln
       - name: Build cyrus-sasl-sasldb

--- a/.github/workflows/enchant.yml
+++ b/.github/workflows/enchant.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Fetch dependencies
         run: powershell winlib-builder/scripts/fetch-deps -lib enchant -version ${{github.event.inputs.php}} -vs ${{steps.virtuals.outputs.vs}} -arch ${{matrix.arch}} -stability ${{github.event.inputs.stability}}
       - name: Setup msbuild
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v2
       - name: Build enchant
         run: cd enchant && msbuild /t:libenchant;libenchant_hunspell /p:Configuration=Release;Platform=${{steps.virtuals.outputs.msarch}};PlatformToolset=${{steps.virtuals.outputs.msts}};WindowsTargetPlatformVersion=${{steps.virtuals.outputs.winsdk}} msvc${{steps.virtuals.outputs.vsnum}}\enchant2.sln
       - name: Install enchant

--- a/.github/workflows/freetype.yml
+++ b/.github/workflows/freetype.yml
@@ -37,7 +37,7 @@ jobs:
           arch: ${{matrix.arch}}
           toolset: ${{steps.virtuals.outputs.toolset}}
       - name: Setup msbuild
-        uses: microsoft/setup-msbuild@v1.0.3
+        uses: microsoft/setup-msbuild@v2
       - name: Set FREETYPE_BUILDFOLDER
         if: ${{steps.virtuals.outputs.vsnum == '15'}}
         run: echo FREETYPE_BUILDFOLDER=vc2017>> %GITHUB_ENV%

--- a/.github/workflows/gettext.yml
+++ b/.github/workflows/gettext.yml
@@ -36,7 +36,7 @@ jobs:
         id: virtuals
         run: powershell winlib-builder/scripts/compute-virtuals -version ${{github.event.inputs.php}} -arch ${{matrix.arch}}
       - name: Setup msbuild
-        uses: microsoft/setup-msbuild@v1.0.3
+        uses: microsoft/setup-msbuild@v2
       - name: Build gettext
         run: cd gettext\MSVC${{steps.virtuals.outputs.vsnum}} && msbuild gettext.sln /p:Configuration=Release /p:Platform=${{steps.virtuals.outputs.msarch}} /p:PlatformToolset=${{steps.virtuals.outputs.msts}} /p:WindowsTargetPlatformVersion=${{steps.virtuals.outputs.winsdk}}
       - name: Install gettext

--- a/.github/workflows/glib.yml
+++ b/.github/workflows/glib.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Fetch dependencies
         run: powershell winlib-builder/scripts/fetch-deps -lib glib -version ${{github.event.inputs.php}} -vs ${{steps.virtuals.outputs.vs}} -arch ${{matrix.arch}} -stability ${{github.event.inputs.stability}}
       - name: Setup msbuild
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v2
       - name: Build glib
         run: cd glib && msbuild /p:Configuration=Release_BundledPCRE;Platform=${{steps.virtuals.outputs.msarch}};PlatformToolset=${{steps.virtuals.outputs.msts}};WindowsTargetPlatformVersion=${{steps.virtuals.outputs.winsdk}};PythonPath=C:\hostedtoolcache\windows\Python\3.7.9\x64 win32\vs${{steps.virtuals.outputs.vsnum}}\glib.sln
       - name: Install glib

--- a/.github/workflows/icu4c.yml
+++ b/.github/workflows/icu4c.yml
@@ -37,7 +37,7 @@ jobs:
           arch: ${{matrix.arch}}
           toolset: ${{steps.virtuals.outputs.toolset}}
       - name: Setup msbuild
-        uses: microsoft/setup-msbuild@v1.0.3
+        uses: microsoft/setup-msbuild@v2
       - name: Build icu4c
         run: cd icu4c && msbuild /p:Configuration=Release;Platform=${{steps.virtuals.outputs.msarch}};PlatformToolset=${{steps.virtuals.outputs.msts}};WindowsTargetPlatformVersion=${{steps.virtuals.outputs.winsdk}} source\allinone\allinone.sln
       - name: Install icu4c

--- a/.github/workflows/imagemagick.yml
+++ b/.github/workflows/imagemagick.yml
@@ -26,7 +26,7 @@ jobs:
           repository: ImageMagick/ImageMagick-Windows.git
           ref: main
       - name: Setup msbuild
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v2
       - name: Compute virtual inputs
         id: virtuals
         run: powershell winlib-builder/scripts/compute-virtuals -version ${{github.event.inputs.php}} -arch ${{matrix.arch}}

--- a/.github/workflows/libffi.yml
+++ b/.github/workflows/libffi.yml
@@ -32,7 +32,7 @@ jobs:
         id: virtuals
         run: powershell winlib-builder/scripts/compute-virtuals -version ${{github.event.inputs.php}} -arch ${{matrix.arch}}
       - name: Setup msbuild
-        uses: microsoft/setup-msbuild@v1.0.3
+        uses: microsoft/setup-msbuild@v2
       - name: Build libffi
         run: cd libffi\win32\${{steps.virtuals.outputs.vs}}_${{matrix.arch}} && msbuild libffi-msvc.sln /p:Configuration=Release /p:Platform=${{steps.virtuals.outputs.msarch}} /p:WindowsTargetPlatformVersion=${{steps.virtuals.outputs.winsdk}}
       - name: Install libffi

--- a/.github/workflows/libiconv.yml
+++ b/.github/workflows/libiconv.yml
@@ -37,7 +37,7 @@ jobs:
           arch: ${{matrix.arch}}
           toolset: ${{steps.virtuals.outputs.toolset}}
       - name: Setup msbuild
-        uses: microsoft/setup-msbuild@v1.0.3
+        uses: microsoft/setup-msbuild@v2
       - name: Build libiconv
         run: cd libiconv\MSVC${{steps.virtuals.outputs.vsnum}} && msbuild libiconv.sln /p:Configuration=Release /p:Platform=${{steps.virtuals.outputs.msarch}} /p:PlatformToolset=${{steps.virtuals.outputs.msts}} /p:WindowsTargetPlatformVersion=${{steps.virtuals.outputs.winsdk}}
       - name: Install libiconv

--- a/.github/workflows/libpng.yml
+++ b/.github/workflows/libpng.yml
@@ -36,7 +36,7 @@ jobs:
         id: virtuals
         run: powershell winlib-builder/scripts/compute-virtuals -version ${{github.event.inputs.php}} -arch ${{matrix.arch}}
       - name: Setup msbuild
-        uses: microsoft/setup-msbuild@v1.0.3
+        uses: microsoft/setup-msbuild@v2
       - name: Fetch zlib
         run: cd libpng\projects\vstudio${{steps.virtuals.outputs.vsyear}} && curl -Lo zlib1212.zip https://zlib.net/zlib1212.zip && 7z x zlib1212.zip
       - name: Build dynamic libpng

--- a/.github/workflows/libsodium.yml
+++ b/.github/workflows/libsodium.yml
@@ -32,7 +32,7 @@ jobs:
         id: virtuals
         run: powershell winlib-builder/scripts/compute-virtuals -version ${{github.event.inputs.php}} -arch ${{matrix.arch}}
       - name: Setup msbuild
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v2
       - name: Build libsodium
         run: cd libsodium\builds\msvc\vs${{steps.virtuals.outputs.vsyear}} && msbuild /t:Rebuild /p:Configuration=StaticRelease;Platform=${{steps.virtuals.outputs.msarch}};PlatformToolset=${{steps.virtuals.outputs.msts}};WindowsTargetPlatformVersion=${{steps.virtuals.outputs.winsdk}} libsodium.sln && msbuild /t:Rebuild /p:Configuration=DynRelease;Platform=${{steps.virtuals.outputs.msarch}};PlatformToolset=${{steps.virtuals.outputs.msts}};WindowsTargetPlatformVersion=${{steps.virtuals.outputs.winsdk}} libsodium.sln
       - name: Install libsodium

--- a/.github/workflows/libssh2_msbuild.yml
+++ b/.github/workflows/libssh2_msbuild.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Fetch dependencies
         run: powershell winlib-builder/scripts/fetch-deps -lib libssh2 -version ${{github.event.inputs.php}} -vs ${{steps.virtuals.outputs.vs}} -arch ${{matrix.arch}} -stability ${{github.event.inputs.stability}}
       - name: Setup msbuild
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v2
       - name: Build libssh2
         run: |
           cd libssh2

--- a/.github/workflows/libxpm.yml
+++ b/.github/workflows/libxpm.yml
@@ -36,7 +36,7 @@ jobs:
         id: virtuals
         run: powershell winlib-builder/scripts/compute-virtuals -version ${{github.event.inputs.php}} -arch ${{matrix.arch}}
       - name: Setup msbuild
-        uses: microsoft/setup-msbuild@v1.0.3
+        uses: microsoft/setup-msbuild@v2
       - name: Patch libxpm
         run: cd libxpm && git apply --ignore-whitespace ..\winlib-builder\patches\libxpm.patch
       - name: Build libxpm

--- a/.github/workflows/mpir.yml
+++ b/.github/workflows/mpir.yml
@@ -32,7 +32,7 @@ jobs:
         id: virtuals
         run: powershell winlib-builder/scripts/compute-virtuals -version ${{github.event.inputs.php}} -arch ${{matrix.arch}}
       - name: Setup msbuild
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v2
       - name: Build mpir
         run: cd mpir && msbuild /p:Configuration=Release;Platform=${{steps.virtuals.outputs.msarch}};PlatformToolset=${{steps.virtuals.outputs.msts}};WindowsTargetPlatformVersion=${{steps.virtuals.outputs.winsdk}} build.vc${{steps.virtuals.outputs.vsnum}}\lib_mpir_gc\lib_mpir_gc.vcxproj
       - name: Install mpir

--- a/.github/workflows/openldap.yml
+++ b/.github/workflows/openldap.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Fetch dependencies
         run: powershell winlib-builder/scripts/fetch-deps -lib openldap -version ${{github.event.inputs.php}} -vs ${{steps.virtuals.outputs.vs}} -arch ${{matrix.arch}} -stability ${{github.event.inputs.stability}}
       - name: Setup msbuild
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v2
       - name: Build openldap
         run: cd openldap\win32\${{steps.virtuals.outputs.vs}} && msbuild /p:Configuration=Release;Platform=${{steps.virtuals.outputs.msarch}};PlatformToolset=${{steps.virtuals.outputs.msts}};WindowsTargetPlatformVersion=${{steps.virtuals.outputs.winsdk}} liblber.sln
       - name: Install openldap


### PR DESCRIPTION
`microsoft/setup-msbuild@v1` uses `node16` which is deprecated; `v2`
claims to change no functionality, only upgrading to `node20`[1].

We rolled a couple of builds (libiconv, libsodium and icu4c), and
checked that the results are sensible (without really testing them).

[1] <https://github.com/microsoft/setup-msbuild/releases/tag/v2>
