### PR TITLE
Update upload action to v4

### DIFF
--- a/.github/workflows/argon2.yml
+++ b/.github/workflows/argon2.yml
@@ -44,7 +44,7 @@ jobs:
           xcopy include\*.h ..\install\include\*
           xcopy argon2_a.* ..\install\lib\*
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/curl.yml
+++ b/.github/workflows/curl.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install curl
         run: cd curl && xcopy /e builds\libcurl-vc${{steps.virtuals.outputs.vsnum}}-${{matrix.arch}}-release-static-ssl-dll-zlib-static-ssh2-dll-ipv6-sspi-nghttp2-dll\* ..\build\*
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: build

--- a/.github/workflows/cyrus-sasl.yml
+++ b/.github/workflows/cyrus-sasl.yml
@@ -55,7 +55,7 @@ jobs:
           xcopy include\md5global.h ..\..\install\include\sasl\*
           xcopy %platform%\Release\libsasl.lib ..\..\install\lib\*
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/enchant.yml
+++ b/.github/workflows/enchant.yml
@@ -58,7 +58,7 @@ jobs:
           xcopy %prefix%\Release\libenchant2.lib ..\install\lib\*
           xcopy %prefix%\Release\libenchant2_hunspell.lib ..\install\lib\*
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/freetype.yml
+++ b/.github/workflows/freetype.yml
@@ -54,7 +54,7 @@ jobs:
           xcopy /e include ..\install\include\freetype2\*
           xcopy objs\${{env.FREETYPE_BUILDFOLDER}}\${{steps.virtuals.outputs.msarch}}\freetype_a.* ..\install\lib\*
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/freetype_cmake.yml
+++ b/.github/workflows/freetype_cmake.yml
@@ -42,7 +42,7 @@ jobs:
           xcopy RelWithDebInfo\freetype_a.pdb ..\..\install\lib\*
           rmdir /s /q ..\..\install\lib\pkgconfig
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/gettext.yml
+++ b/.github/workflows/gettext.yml
@@ -57,7 +57,7 @@ jobs:
           xcopy libintl_static\%release_out%\libintl_a.lib ..\..\install\lib\*
           xcopy libintl_static\%release_out%\libintl_a.pdb ..\..\install\lib\*
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/glib.yml
+++ b/.github/workflows/glib.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install glib
         run: xcopy /e vs${{steps.virtuals.outputs.vsnum}}\${{steps.virtuals.outputs.msarch}} install\*
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/icu4c.yml
+++ b/.github/workflows/icu4c.yml
@@ -54,7 +54,7 @@ jobs:
           xcopy %WB_LIBDIR%\* build\lib\*
           del build\lib\*test*.*
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: build

--- a/.github/workflows/imagemagick.yml
+++ b/.github/workflows/imagemagick.yml
@@ -75,7 +75,7 @@ jobs:
           del ..\..\install\lib\CORE_RL_raqm_.pdb
           xcopy ..\ImageMagick\LICENSE ..\..\install\*
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ImageMagick-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/imap.yml
+++ b/.github/workflows/imap.yml
@@ -44,7 +44,7 @@ jobs:
           xcopy c-client\*.h ..\install\include\c-client\*
           xcopy c-client\cclient_a.lib ..\install\lib\*
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/libavif.yml
+++ b/.github/workflows/libavif.yml
@@ -63,7 +63,7 @@ jobs:
           xcopy RelWithDebInfo\avif_a.pdb ..\install\lib\*
           rmdir /s /q ..\install\lib\pkgconfig
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/libffi.yml
+++ b/.github/workflows/libffi.yml
@@ -50,7 +50,7 @@ jobs:
               xcopy win32\${{steps.virtuals.outputs.vs}}_${{matrix.arch}}\Release\libffi.pdb ..\install\lib\*
           )
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/libiconv.yml
+++ b/.github/workflows/libiconv.yml
@@ -49,7 +49,7 @@ jobs:
           xcopy ${{steps.virtuals.outputs.msarch}}\lib\*.lib ..\..\install\lib\*
           xcopy ${{steps.virtuals.outputs.msarch}}\lib\*.pdb ..\..\install\lib\*
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/libjpeg.yml
+++ b/.github/workflows/libjpeg.yml
@@ -45,7 +45,7 @@ jobs:
           rmdir /s /q ..\install\doc
           rmdir /s /q ..\install\lib\pkgconfig
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/liblzma.yml
+++ b/.github/workflows/liblzma.yml
@@ -41,7 +41,7 @@ jobs:
           cmake --install . --config RelWithDebInfo --prefix ..\..\install
           IF EXIST RelWithDebInfo\liblzma_a.pdb xcopy RelWithDebInfo\liblzma_a.pdb ..\..\install\lib\*
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/libmemcached.yml
+++ b/.github/workflows/libmemcached.yml
@@ -51,7 +51,7 @@ jobs:
           xcopy src\libmemcachedprotocol\RelWithDebInfo\libmemcachedprotocol.pdb ..\..\install\bin\*
           xcopy src\libmemcachedutil\RelWithDebInfo\libmemcachedutil.pdb ..\..\install\bin\*
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: libmemcached-${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/libpng.yml
+++ b/.github/workflows/libpng.yml
@@ -59,7 +59,7 @@ jobs:
           xcopy %objdir%\Release\libpng.lib ..\..\..\install\lib\*
           xcopy "%objdir%\Release Library\libpng_a.*" ..\..\..\install\lib\*
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/librdkafka.yml
+++ b/.github/workflows/librdkafka.yml
@@ -52,7 +52,7 @@ jobs:
           ren ..\install\LICENSES.txt LICENSE
           del /s /q ..\install\share
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: librdkafka-${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/libsodium.yml
+++ b/.github/workflows/libsodium.yml
@@ -48,7 +48,7 @@ jobs:
           xcopy bin\%platform%\Release\%toolset%\dynamic\libsodium.lib ..\install\lib\*
           copy bin\%platform%\Release\%toolset%\static\libsodium.lib ..\install\lib\libsodium_a.lib
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/libssh2.yml
+++ b/.github/workflows/libssh2.yml
@@ -52,7 +52,7 @@ jobs:
           del /s /q ..\build\lib\pkgconfig\*
           del /s /q ..\build\share\*
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: build

--- a/.github/workflows/libssh2_msbuild.yml
+++ b/.github/workflows/libssh2_msbuild.yml
@@ -53,7 +53,7 @@ jobs:
           xcopy win32\Release_lib\libssh2_a.* ..\install\lib\*
           xcopy win32\Release_dll\libssh2.lib ..\install\lib\*
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/libtidy.yml
+++ b/.github/workflows/libtidy.yml
@@ -51,7 +51,7 @@ jobs:
           copy RelWithDebInfo\tidy.pdb ..\build\bin\tidy.pdb
           copy RelWithDebInfo\tidys.pdb ..\build\lib\tidy_a.pdb
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: build

--- a/.github/workflows/libwebp.yml
+++ b/.github/workflows/libwebp.yml
@@ -49,7 +49,7 @@ jobs:
           xcopy src\webp\*.h ..\build\include\webp\*
           xcopy output\release-static\${{matrix.arch}}\lib\* ..\build\lib\*
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: build

--- a/.github/workflows/libxml2.yml
+++ b/.github/workflows/libxml2.yml
@@ -55,7 +55,7 @@ jobs:
           del /q install\bin\test*
           del /q install\bin\xml*.pdb
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/libxpm.yml
+++ b/.github/workflows/libxpm.yml
@@ -47,7 +47,7 @@ jobs:
           xcopy ..\..\include\X11\* ..\..\..\install\include\X11\*
           xcopy "..\builds\${{steps.virtuals.outputs.msarch}}\Static Release\libxpm_a.*" ..\..\..\install\lib\*
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/libxslt.yml
+++ b/.github/workflows/libxslt.yml
@@ -53,7 +53,7 @@ jobs:
           xcopy lib\* ..\..\install\lib\*
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/libzip.yml
+++ b/.github/workflows/libzip.yml
@@ -56,7 +56,7 @@ jobs:
           )
           rmdir /s /q ..\..\install\lib\pkgconfig
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/libzstd.yml
+++ b/.github/workflows/libzstd.yml
@@ -49,7 +49,7 @@ jobs:
           copy COPYING ..\install
           copy LICENSE ..\install
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: libzstd-${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/lmdb.yml
+++ b/.github/workflows/lmdb.yml
@@ -45,7 +45,7 @@ jobs:
           xcopy lmdb.h ..\..\..\build\include\*
           xcopy liblmdb_a.* ..\..\..\build\lib\*
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: build

--- a/.github/workflows/mpir.yml
+++ b/.github/workflows/mpir.yml
@@ -44,7 +44,7 @@ jobs:
           xcopy lib\${{steps.virtuals.outputs.msarch}}\Release\mpir.h ..\install\include\mpir\*
           xcopy build.vc${{steps.virtuals.outputs.vsnum}}\lib_mpir_gc\${{steps.virtuals.outputs.msarch}}\Release\mpir_a.??? ..\install\lib\*
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/net-snmp.yml
+++ b/.github/workflows/net-snmp.yml
@@ -64,7 +64,7 @@ jobs:
           xcopy win32\libsnmp\release\libsnmp.pdb ..\install\lib\*
           xcopy mibs\* ..\install\share\mibs\*
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/nghttp2.yml
+++ b/.github/workflows/nghttp2.yml
@@ -49,7 +49,7 @@ jobs:
           del /s /q ..\winlib-builder\build\lib\pkgconfig\*
           del /s /q ..\winlib-builder\build\share\*
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: winlib-builder/build

--- a/.github/workflows/oniguruma.yml
+++ b/.github/workflows/oniguruma.yml
@@ -50,7 +50,7 @@ jobs:
           xcopy onig.lib ..\install\lib\*
           copy onig_s.lib ..\install\lib\onig_a.lib
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/openldap.yml
+++ b/.github/workflows/openldap.yml
@@ -50,7 +50,7 @@ jobs:
           xcopy out\libldap\${{steps.virtuals.outputs.msarch}}\Release\o*.lib ..\install\lib\*
           xcopy out\libldap\${{steps.virtuals.outputs.msarch}}\Release\o*.pdb ..\install\lib\*
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -62,7 +62,7 @@ jobs:
           xcopy /s /e C:\usr\local\ssl\lib ..\install\lib\*
           xcopy apps\openssl.cnf ..\install\*
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/postgresql.yml
+++ b/.github/workflows/postgresql.yml
@@ -68,7 +68,7 @@ jobs:
           xcopy ReleaseStatic\libpq\libpq_a.lib ..\install\lib\*
           xcopy ReleaseStatic\libpq\libpq_a.pdb ..\install\lib\*
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/pslib.yml
+++ b/.github/workflows/pslib.yml
@@ -48,7 +48,7 @@ jobs:
           xcopy include\libps\*.h ..\install\include\libps\*
           xcopy RelWithDebInfo\pslib.lib ..\install\lib\*
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/pthreads.yml
+++ b/.github/workflows/pthreads.yml
@@ -54,7 +54,7 @@ jobs:
           if exist COPYING xcopy COPYING ..\build\*
           if exist LICENSE xcopy LICENSE ..\build\*
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: build

--- a/.github/workflows/qdbm.yml
+++ b/.github/workflows/qdbm.yml
@@ -47,7 +47,7 @@ jobs:
           del ..\install\include\qdbm\hovel.h ..\install\include\qdbm\myconf.h
           xcopy *.lib ..\install\lib\*
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/sqlite3.yml
+++ b/.github/workflows/sqlite3.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install sqlite3
         run: cd sqlite3 && nmake PREFIX=..\build install
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: build

--- a/.github/workflows/wineditline.yml
+++ b/.github/workflows/wineditline.yml
@@ -45,7 +45,7 @@ jobs:
           xcopy build\src\RelWithDebInfo\edit_a.lib ..\install\lib\*
           xcopy build\src\RelWithDebInfo\edit_a.pdb ..\install\lib\*
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: install

--- a/.github/workflows/zlib.yml
+++ b/.github/workflows/zlib.yml
@@ -51,7 +51,7 @@ jobs:
           xcopy zlib_a.lib ..\build\lib\*
           xcopy zlib_a.pdb ..\build\lib\*
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
           path: build


### PR DESCRIPTION
`actions/checkout@v3` is deprecated, so we update to v4.  We do not expect any trouble with this update, since we already treated the upload artifacts as immutable, but nonetheless we did a couple of test builds (argon2, zlib and libjpeg) and the results appear to be fine.