### PR TITLE
Don't build *_uwp projects of icu4c

### DIFF
--- a/.github/workflows/icu4c.yml
+++ b/.github/workflows/icu4c.yml
@@ -38,6 +38,10 @@ jobs:
           toolset: ${{steps.virtuals.outputs.toolset}}
       - name: Setup msbuild
         uses: microsoft/setup-msbuild@v2
+      - name: Remove UWP projects
+        run: |
+          cd icu4c\source\allinone
+          for /f %%i in ('dotnet sln allinone.sln list ^| findstr _uwp') do @dotnet sln allinone.sln remove %%i
       - name: Build icu4c
         run: cd icu4c && msbuild /p:Configuration=Release;Platform=${{steps.virtuals.outputs.msarch}};PlatformToolset=${{steps.virtuals.outputs.msts}};WindowsTargetPlatformVersion=${{steps.virtuals.outputs.winsdk}} source\allinone\allinone.sln
       - name: Install icu4c


### PR DESCRIPTION
These are superfluous for PHP, and apparently may cause issues[1].

[1] <https://github.com/winlibs/winlib-builder/actions/runs/10752666056/job/29821234927#step:7:4613>

---

I've did a [test build](https://github.com/winlibs/winlib-builder/actions/runs/10759101221), and checked that the artifacts are basically the same as without this patch.

An alternative to this could be to exclude the UWP projects from the icu4c repository in the first place. This had the additional advantage that builds not using winlib-builder would not have to build the UWP projects (what requires having UWP support installed in Visual Studio; a couple of additional GBs). The obvious drawback would be that versions already have been commited/tagged would still build the UWP projects.