### PR TITLE
Set up NASM for libjpeg-turbo builds

### DIFF
--- a/.github/workflows/libjpeg.yml
+++ b/.github/workflows/libjpeg.yml
@@ -31,6 +31,8 @@ jobs:
       - name: Compute virtual inputs
         id: virtuals
         run: powershell winlib-builder/scripts/compute-virtuals -version ${{github.event.inputs.php}} -arch ${{matrix.arch}}
+      - name: Setup NASM
+        uses: ilammy/setup-nasm@v1
       - name: Configure libjpeg
         run: cd libjpeg && cmake -G "Visual Studio 16 2019" -A ${{steps.virtuals.outputs.msarch}} -T ${{steps.virtuals.outputs.msts}} -DWITH_JPEG8=1 -DWITH_CRT_DLL=1 -DENABLE_SHARED=0 -DWITH_TURBOJPEG=0 .
       - name: Build libjpeg


### PR DESCRIPTION
Without NASM, SIMD extensions are disabled[1].

[1] <https://github.com/winlibs/winlib-builder/actions/runs/10759635255/job/29836551341#step:5:59>

---

Test build: https://github.com/winlibs/winlib-builder/actions/runs/10759674769. I haven't tested that yet, though, let alone done some benchmarking.