### PR TITLE
Don't ask for the stability if there are no dependecies

### DIFF
--- a/.github/workflows/gettext.yml
+++ b/.github/workflows/gettext.yml
@@ -8,10 +8,6 @@ on:
       php:
         description: PHP version to build for
         required: true
-      stability:
-        description: the series stability
-        required: false
-        default: 'staging'
 defaults:
   run:
     shell: cmd

--- a/.github/workflows/libmemcached.yml
+++ b/.github/workflows/libmemcached.yml
@@ -8,10 +8,6 @@ on:
       php:
         description: PHP version to build for
         required: true
-      stability:
-        description: the series stability
-        required: false
-        default: 'staging'
 defaults:
   run:
     shell: cmd

--- a/.github/workflows/libpng.yml
+++ b/.github/workflows/libpng.yml
@@ -8,10 +8,6 @@ on:
       php:
         description: PHP version to build for
         required: true
-      stability:
-        description: the series stability
-        required: false
-        default: 'staging'
 defaults:
   run:
     shell: cmd

--- a/.github/workflows/libtidy.yml
+++ b/.github/workflows/libtidy.yml
@@ -8,10 +8,6 @@ on:
       php:
         description: PHP version to build for
         required: true
-      stability:
-        description: the series stability
-        required: false
-        default: 'staging'
 defaults:
   run:
     shell: cmd
@@ -35,8 +31,6 @@ jobs:
       - name: Compute virtual inputs
         id: virtuals
         run: powershell winlib-builder/scripts/compute-virtuals -version ${{github.event.inputs.php}} -arch ${{matrix.arch}}
-      - name: Fetch dependencies
-        run: powershell winlib-builder/scripts/fetch-deps -lib libtidy -version ${{github.event.inputs.php}} -vs ${{steps.virtuals.outputs.vs}} -arch ${{matrix.arch}} -stability ${{github.event.inputs.stability}}
       - name: Configure libtidy
         run: cd libtidy && cmake -G "Visual Studio 16 2019" -A ${{steps.virtuals.outputs.msarch}} -T ${{steps.virtuals.outputs.msts}} .
       - name: Build libtidy

--- a/.github/workflows/libwebp.yml
+++ b/.github/workflows/libwebp.yml
@@ -8,10 +8,6 @@ on:
       php:
         description: PHP version to build for
         required: true
-      stability:
-        description: the series stability
-        required: false
-        default: 'staging'
 defaults:
   run:
     shell: cmd

--- a/.github/workflows/libxpm.yml
+++ b/.github/workflows/libxpm.yml
@@ -8,10 +8,6 @@ on:
       php:
         description: PHP version to build for
         required: true
-      stability:
-        description: the series stability
-        required: false
-        default: 'staging'
 defaults:
   run:
     shell: cmd

--- a/.github/workflows/libzstd.yml
+++ b/.github/workflows/libzstd.yml
@@ -8,10 +8,6 @@ on:
       php:
         description: PHP version to build for
         required: true
-      stability:
-        description: the series stability
-        required: false
-        default: 'staging'
 defaults:
   run:
     shell: cmd

--- a/.github/workflows/nghttp2.yml
+++ b/.github/workflows/nghttp2.yml
@@ -8,10 +8,6 @@ on:
       php:
         description: PHP version to build for
         required: true
-      stability:
-        description: the series stability
-        required: false
-        default: 'staging'
 defaults:
   run:
     shell: cmd
@@ -35,8 +31,6 @@ jobs:
       - name: Compute virtual inputs
         id: virtuals
         run: powershell winlib-builder/scripts/compute-virtuals -version ${{github.event.inputs.php}} -arch ${{matrix.arch}}
-      - name: Fetch dependencies
-        run: powershell winlib-builder/scripts/fetch-deps -lib nghttp2 -version ${{github.event.inputs.php}} -vs ${{steps.virtuals.outputs.vs}} -arch ${{matrix.arch}} -stability ${{github.event.inputs.stability}}
       - name: Configure nghttp2
         run: cd nghttp2 && cmake -G "Visual Studio 16 2019" -A ${{steps.virtuals.outputs.msarch}} -T ${{steps.virtuals.outputs.msts}} .
       - name: Build nghttp2

--- a/.github/workflows/oniguruma.yml
+++ b/.github/workflows/oniguruma.yml
@@ -8,10 +8,6 @@ on:
       php:
         description: PHP version to build for
         required: true
-      stability:
-        description: the series stability
-        required: false
-        default: 'staging'
 defaults:
   run:
     shell: cmd

--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -8,10 +8,6 @@ on:
       php:
         description: PHP version to build for
         required: true
-      stability:
-        description: the series stability
-        required: false
-        default: 'staging'
 defaults:
   run:
     shell: cmd

--- a/.github/workflows/pslib.yml
+++ b/.github/workflows/pslib.yml
@@ -8,10 +8,6 @@ on:
       php:
         description: PHP version to build for
         required: true
-      stability:
-        description: the series stability
-        required: false
-        default: 'staging'
 defaults:
   run:
     shell: cmd

--- a/.github/workflows/pthreads.yml
+++ b/.github/workflows/pthreads.yml
@@ -8,10 +8,6 @@ on:
       php:
         description: PHP version to build for
         required: true
-      stability:
-        description: the series stability
-        required: false
-        default: 'staging'
 defaults:
   run:
     shell: cmd


### PR DESCRIPTION
This is just confusing for builders.  We also remove the calls to fetch-deps.ps1 if there are no dependencies to fetch.