### PR TITLE
Update libavif.yml for newer libavif versions

### DIFF
--- a/.github/workflows/libavif.yml
+++ b/.github/workflows/libavif.yml
@@ -53,7 +53,7 @@ jobs:
           xcopy Release\aom.lib .\aom_a.lib*
           xcopy .\aom_a.lib ..\..\..\..\install\lib\
       - name: Configure libavif
-        run: cd libavif && cmake -G "Visual Studio 17 2022" -A ${{steps.virtuals.outputs.msarch}} -T ${{steps.virtuals.outputs.msts}} -DAVIF_CODEC_AOM=1 -DAVIF_LOCAL_AOM=1 -DAVIF_ENABLE_WERROR=0 -DBUILD_SHARED_LIBS=0 .
+        run: cd libavif && cmake -G "Visual Studio 17 2022" -A ${{steps.virtuals.outputs.msarch}} -T ${{steps.virtuals.outputs.msts}} -DAVIF_LIBYUV=LOCAL -DAVIF_CODEC_AOM=LOCAL -DAVIF_ENABLE_WERROR=0 -DBUILD_SHARED_LIBS=0 .
       - name: Build libavif
         run: cd libavif && cmake --build . --config RelWithDebInfo
       - name: Install libavif


### PR DESCRIPTION
Newer libavif versions require libyuf, so we enable the local build. Furthermore, we need to adjust the AOM options, which have obviously been changed.

---

Note that this is no longer compatible with libavif 0.9, what may not be a problem, though.