### PR TITLE
Add builder for BrianGladman/mpir

### DIFF
--- a/.github/workflows/mpir_gladman.yml
+++ b/.github/workflows/mpir_gladman.yml
@@ -1,0 +1,50 @@
+name: Build BrianGladman/mpir
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: mpir tag to build
+        required: true
+      php:
+        description: PHP version to build for
+        required: true
+defaults:
+  run:
+    shell: cmd
+jobs:
+  build:
+    strategy:
+      matrix:
+          arch: [x64, x86]
+    runs-on: windows-2022
+    steps:
+      - name: Checkout winlib-builder
+        uses: actions/checkout@v4
+        with:
+          path: winlib-builder
+      - name: Checkout mpir
+        uses: actions/checkout@v4
+        with:
+          path: mpir
+          repository: BrianGladman/mpir
+          ref: ${{github.event.inputs.version}}
+      - name: Compute virtual inputs
+        id: virtuals
+        run: powershell winlib-builder/scripts/compute-virtuals -version ${{github.event.inputs.php}} -arch ${{matrix.arch}}
+      - name: Setup msbuild
+        uses: microsoft/setup-msbuild@v2
+      - name: Build mpir
+        run: cd mpir\msvc\vs22 && msbuild.exe /p:Configuration=Release;Platform=${{steps.virtuals.outputs.msarch}};PlatformToolset=${{steps.virtuals.outputs.msts}};WindowsTargetPlatformVersion=${{steps.virtuals.outputs.winsdk}};TargetName=mpir_a lib_mpir_gc\lib_mpir_gc.vcxproj
+      - name: Install mpir
+        run: |
+          cd mpir
+          xcopy msvc\vs22\lib_mpir_gc\${{steps.virtuals.outputs.msarch}}\Release\config.h ..\install\include\mpir\*
+          xcopy msvc\vs22\lib_mpir_gc\${{steps.virtuals.outputs.msarch}}\Release\gmp-mparam.h ..\install\include\mpir\*
+          xcopy msvc\vs22\lib_mpir_gc\${{steps.virtuals.outputs.msarch}}\Release\gmp.h ..\install\include\mpir\*
+          xcopy msvc\vs22\lib_mpir_gc\${{steps.virtuals.outputs.msarch}}\Release\mpir.h ..\install\include\mpir\*
+          xcopy msvc\vs22\lib_mpir_gc\${{steps.virtuals.outputs.msarch}}\Release\mpir_a.??? ..\install\lib\*
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
+          path: install


### PR DESCRIPTION
Frankly, I'm not sure what to do about mpir, which is a fork of libgmp, used to build ext/gmp on Windows. The latest release (3.0.0) was published more than seven years ago, and the project seems to be abandoned. There is https://github.com/BrianGladman/mpir, a fork that focuses on Windows, which had some activity, but according to https://github.com/wbhart/mpir/issues/272, neither the original work, nor Brian Gladman's fork are still maintained.

If no further maintenance will happen, we may consider to switch to libgmp, although there is no support for native Windows builds (only autoconf), which is likely one of the reasons why we had chosen mpir; the other is that mpir provides optimized implementations (in Assembler, using SIMD instructions), although I don't think that any of these have been used for our official builds. Those that are offered out of the box by BrianGladman/mpir use AVX and maybe AVX2 instructions, and that would not fit with our PHP builds which are constrained to SSE2. If we switch to libgmp, we may even consider using mini-gmp which is a minimal variant consisting of a few C files only, but claims to be slow since it's lacking optimizations. It might not be that bad, considering that we didn't deploy the optimizations of mpir.

Anyhow, to make some progress, this PR add a builder for BrianGladman/mpir (which has at least one [relevant bug fix](https://github.com/BrianGladman/mpir/commit/33be9007f95b85230da2330ef3ed525896370cc2)). A [test build](https://github.com/cmb69/winlib-builder/actions/runs/11420077805) showed no issues running the ext/gmp test suite on `master`/x64. Since that repo never released tags, and the version numbers have never been bumped, I have no idea what to do about that. Of course, we could modify the version numbers, or just call it mpir-3.0.0-1 or something.