### PR TITLE
Include applink.c in distribution

### DIFF
--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -59,7 +59,7 @@ jobs:
           nmake install
           xcopy C:\usr\local\ssl\bin ..\install\bin\*
           xcopy /e C:\usr\local\ssl\include ..\install\include\*
-          xcopy ms\applink.c ..\install\include\openssl\*
+          if not exist ..\install\include\openssl\applink.c xcopy ms\applink.c ..\install\include\openssl\*
           xcopy /s /e C:\usr\local\ssl\lib ..\install\lib\*
           xcopy apps\openssl.cnf ..\install\*
       - name: Upload artifacts

--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -59,6 +59,7 @@ jobs:
           nmake install
           xcopy C:\usr\local\ssl\bin ..\install\bin\*
           xcopy /e C:\usr\local\ssl\include ..\install\include\*
+          xcopy ms\applink.c ..\install\include\openssl\*
           xcopy /s /e C:\usr\local\ssl\lib ..\install\lib\*
           xcopy apps\openssl.cnf ..\install\*
       - name: Upload artifacts


### PR DESCRIPTION
For some reason applink.c is not installed for ARM64 builds[1].  That might be an upstream issue, but would need to be checked on a Windows ARM64 machine; for now, it might be best to just install the file manually, and see where that goes.

[1] <https://github.com/php/php-src/issues/16827>