### PR TITLE
Add capstone builder

### DIFF
--- a/.github/workflows/capstone.yml
+++ b/.github/workflows/capstone.yml
@@ -1,0 +1,47 @@
+name: Build capstone
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: capstone tag to build
+        required: true
+      php:
+        description: PHP version to build for
+        required: true
+defaults:
+  run:
+    shell: cmd
+jobs:
+  build:
+    strategy:
+      matrix:
+          arch: [x64, x86]
+    runs-on: windows-2022
+    steps:
+      - name: Checkout winlib-builder
+        uses: actions/checkout@v4
+        with:
+          path: winlib-builder
+      - name: Checkout capstone
+        uses: actions/checkout@v4
+        with:
+          path: capstone
+          repository: libcapstone/libcapstone
+          ref: ${{github.event.inputs.version}}
+      - name: Compute virtual inputs
+        id: virtuals
+        run: powershell winlib-builder/scripts/compute-virtuals -version ${{github.event.inputs.php}} -arch ${{matrix.arch}}
+      - name: Configure capstone
+        run: cd capstone && md build && cd build && cmake -G "Visual Studio 17 2022" -A ${{steps.virtuals.outputs.msarch}} -T ${{steps.virtuals.outputs.msts}} -DCMAKE_SYSTEM_VERSION=${{steps.virtuals.outputs.winsdk}} -DCAPSTONE_BUILD_TESTS=OFF -DCAPSTONE_BUILD_CSTOOL=OFF ..
+      - name: Build capstone
+        run: cd capstone\build && cmake --build . --config RelWithDebInfo
+      - name: Install capstone
+        run: |
+          cd capstone\build
+          cmake --install . --config RelWithDebInfo --prefix ..\..\install
+          xcopy RelWithDebInfo\capstone.pdb ..\..\install\bin\*
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
+          path: install


### PR DESCRIPTION
This builds directly from https://github.com/libcapstone/libcapstone. Test build available at https://github.com/cmb69/winlib-builder/actions/runs/11892246323.

I don't think it makes to roll this out as core package. I had hoped that it shows symbols in back-traces, but that is apparently only supported for GDB for now (`ZEND_JIT_DEBUG_GDB`; see https://wiki.php.net/rfc/jit#jit_debugging). 