### PR TITLE
Also build static nghttp2

### DIFF
--- a/.github/workflows/nghttp2.yml
+++ b/.github/workflows/nghttp2.yml
@@ -40,6 +40,7 @@ jobs:
           cd nghttp2
           cmake --install . --config RelWithDebInfo --prefix ..\winlib-builder\build
           copy lib\RelWithDebInfo\nghttp2.pdb ..\winlib-builder\build\bin
+          copy lib\RelWithDebInfo\nghttp2_static.pdb ..\winlib-builder\builder\lib
           del /s /q ..\winlib-builder\build\lib\pkgconfig\*
           del /s /q ..\winlib-builder\build\share\*
       - name: Upload artifacts

--- a/.github/workflows/nghttp2.yml
+++ b/.github/workflows/nghttp2.yml
@@ -32,7 +32,7 @@ jobs:
         id: virtuals
         run: powershell winlib-builder/scripts/compute-virtuals -version ${{github.event.inputs.php}} -arch ${{matrix.arch}}
       - name: Configure nghttp2
-        run: cd nghttp2 && cmake -G "Visual Studio 17 2022" -A ${{steps.virtuals.outputs.msarch}} -T ${{steps.virtuals.outputs.msts}} -DCMAKE_SYSTEM_VERSION=${{steps.virtuals.outputs.winsdk}} .
+        run: cd nghttp2 && cmake -G "Visual Studio 17 2022" -A ${{steps.virtuals.outputs.msarch}} -T ${{steps.virtuals.outputs.msts}} -DCMAKE_SYSTEM_VERSION=${{steps.virtuals.outputs.winsdk}} -DBUILD_STATIC_LIBS=ON .
       - name: Build nghttp2
         run: cd nghttp2 && cmake --build . --config RelWithDebInfo --target nghttp2
       - name: Install nghttp2

--- a/.github/workflows/nghttp2.yml
+++ b/.github/workflows/nghttp2.yml
@@ -40,7 +40,7 @@ jobs:
           cd nghttp2
           cmake --install . --config RelWithDebInfo --prefix ..\winlib-builder\build
           copy lib\RelWithDebInfo\nghttp2.pdb ..\winlib-builder\build\bin
-          copy lib\RelWithDebInfo\nghttp2_static.pdb ..\winlib-builder\builder\lib
+          copy lib\RelWithDebInfo\nghttp2_static.pdb ..\winlib-builder\build\lib
           del /s /q ..\winlib-builder\build\lib\pkgconfig\*
           del /s /q ..\winlib-builder\build\share\*
       - name: Upload artifacts

--- a/.github/workflows/nghttp2.yml
+++ b/.github/workflows/nghttp2.yml
@@ -32,9 +32,9 @@ jobs:
         id: virtuals
         run: powershell winlib-builder/scripts/compute-virtuals -version ${{github.event.inputs.php}} -arch ${{matrix.arch}}
       - name: Configure nghttp2
-        run: cd nghttp2 && cmake -G "Visual Studio 17 2022" -A ${{steps.virtuals.outputs.msarch}} -T ${{steps.virtuals.outputs.msts}} -DCMAKE_SYSTEM_VERSION=${{steps.virtuals.outputs.winsdk}} -DBUILD_STATIC_LIBS=ON .
+        run: cd nghttp2 && cmake -G "Visual Studio 17 2022" -A ${{steps.virtuals.outputs.msarch}} -T ${{steps.virtuals.outputs.msts}} -DCMAKE_SYSTEM_VERSION=${{steps.virtuals.outputs.winsdk}} -DENABLE_LIB_ONLY=ON -DBUILD_STATIC_LIBS=ON .
       - name: Build nghttp2
-        run: cd nghttp2 && cmake --build . --config RelWithDebInfo --target nghttp2
+        run: cd nghttp2 && cmake --build . --config RelWithDebInfo
       - name: Install nghttp2
         run: |
           cd nghttp2


### PR DESCRIPTION
Per se, this doesn't change much, unless we also build cURL against a static nghttp2. To not require to patch cURL when doing this, I've sticked with the default name nghttp2_static.lib (our naming convention would call that libnghtt2_a.lib, but the import library already does not conform to our naming conventions; and these might be something we want to consider to change anyway).

PS:

A [test build](https://github.com/winlibs/winlib-builder/actions/runs/12052016778) is available.

Note that there is the branch https://github.com/winlibs/nghttp2/tree/nghttp2-1.20.0-with-static where apparently this had been done many ago, but apparently that has never been used. Don't know why.