### PR TITLE
Build libcurl against a static nghttp2 library

### DIFF
--- a/.github/workflows/curl.yml
+++ b/.github/workflows/curl.yml
@@ -43,9 +43,9 @@ jobs:
           arch: ${{matrix.arch}}
           toolset: ${{steps.virtuals.outputs.toolset}}
       - name: Build curl
-        run: cd curl\winbuild && nmake /f Makefile.vc mode=static VC=${{steps.virtuals.outputs.vsnum}} WITH_DEVEL=..\..\deps WITH_SSL=dll WITH_ZLIB=static WITH_NGHTTP2=dll WITH_SSH2=dll ENABLE_WINSSL=no USE_IDN=yes ENABLE_IPV6=yes GEN_PDB=yes DEBUG=no MACHINE=${{matrix.arch}} CURL_DISABLE_MQTT=1
+        run: cd curl\winbuild && nmake /f Makefile.vc mode=static VC=${{steps.virtuals.outputs.vsnum}} WITH_DEVEL=..\..\deps WITH_SSL=dll WITH_ZLIB=static WITH_NGHTTP2=static WITH_SSH2=dll ENABLE_WINSSL=no USE_IDN=yes ENABLE_IPV6=yes GEN_PDB=yes DEBUG=no MACHINE=${{matrix.arch}} CURL_DISABLE_MQTT=1
       - name: Install curl
-        run: cd curl && xcopy /e builds\libcurl-vc${{steps.virtuals.outputs.vsnum}}-${{matrix.arch}}-release-static-ssl-dll-zlib-static-ssh2-dll-ipv6-sspi-nghttp2-dll\* ..\build\*
+        run: cd curl && xcopy /e builds\libcurl-vc${{steps.virtuals.outputs.vsnum}}-${{matrix.arch}}-release-static-ssl-dll-zlib-static-ssh2-dll-ipv6-sspi-nghttp2-static\* ..\build\*
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
This is just a quick draft, and depends on #31. I've did a build locally, and couldn't find any issues. This is triggered by some recent issues with PHP 8.4 with somewhat older Apache installations, where php_curl.dll may fail to load due to nghttp2.dll (which is shipped by Apache on Windows builds) being not quite up to date. Building cURL against a static nghttp2 lib would obviously solve that.

A minor drawback is the increase in size. php_curl.dll will get ~15% larger (as will curl.exe), but that isn't a real problem. A somewhat bigger problem would be security updates, although so far we rebuilt cURL usually anyway after updating nghttp2. And there is also the problem that ext/curl checks for nghttp2.lib which is the import library. However, the biggest issue would be with external PHP extensions relying on nghttp2.dll being available in the PHP installation folder, what is currently the case, because all used DLLs are copied to there when doing a snapshot build. If ext/curl would be build against a static nghttp2 lib, that would no longer be the case. I don't know though, whether any external extension would require nghttp2.dll. If need be, we could patch the build scripts to install nghttp2.dll (I guess; never had a closer look how that is implemented).

PS: if we want to support building against a static nghttp, we probably want to introduce an action parameter defaulting to "dll" for BC reasons (but can be set to "static").