### PR TITLE
Update libzstd builder

### DIFF
--- a/.github/workflows/libzstd.yml
+++ b/.github/workflows/libzstd.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Patch libzstd
         run: cd libzstd && git apply --ignore-whitespace ..\winlib-builder\patches\libzstd.patch
       - name: Configure libzstd
-        run: cd libzstd\build\cmake && cmake -G "Visual Studio 17 2022" -A ${{steps.virtuals.outputs.msarch}} -T ${{steps.virtuals.outputs.msts}} -DCMAKE_SYSTEM_VERSION=${{steps.virtuals.outputs.winsdk}} -DZSTD_BUILD_PROGRAMS=OFF .
+        run: cd libzstd\build\cmake && cmake -G "Visual Studio 17 2022" -A ${{steps.virtuals.outputs.msarch}} -T ${{steps.virtuals.outputs.msts}} -DCMAKE_SYSTEM_VERSION=${{steps.virtuals.outputs.winsdk}} -DZSTD_BUILD_PROGRAMS=OFF -DCMAKE_RC_FLAGS=-I${{github.workspace}}\libzstd\lib .
       - name: Build libzstd
         run: cd libzstd\build\cmake && cmake --build . --config RelWithDebInfo
       - name: Install libzstd

--- a/.github/workflows/libzstd.yml
+++ b/.github/workflows/libzstd.yml
@@ -34,13 +34,15 @@ jobs:
       - name: Patch libzstd
         run: cd libzstd && git apply --ignore-whitespace ..\winlib-builder\patches\libzstd.patch
       - name: Configure libzstd
-        run: cd libzstd\build\cmake && cmake -G "Visual Studio 17 2022" -A ${{steps.virtuals.outputs.msarch}} -T ${{steps.virtuals.outputs.msts}} -DCMAKE_SYSTEM_VERSION=${{steps.virtuals.outputs.winsdk}} .
+        run: cd libzstd\build\cmake && cmake -G "Visual Studio 17 2022" -A ${{steps.virtuals.outputs.msarch}} -T ${{steps.virtuals.outputs.msts}} -DCMAKE_SYSTEM_VERSION=${{steps.virtuals.outputs.winsdk}} -DZSTD_BUILD_PROGRAMS=OFF .
       - name: Build libzstd
         run: cd libzstd\build\cmake && cmake --build . --config RelWithDebInfo
       - name: Install libzstd
         run: |
           cd libzstd\build\cmake
           cmake --install . --config RelWithDebInfo --prefix ..\..\..\install
+          xcopy lib\RelWithDebInfo\libzstd.pdb ..\..\..\install\bin\*
+          xcopy lib\RelWithDebInfo\libzstd_a.pdb ..\..\..\install\lib\*
           cd ..\..
           copy COPYING ..\install
           copy LICENSE ..\install

--- a/patches/libzstd.patch
+++ b/patches/libzstd.patch
@@ -1,25 +1,18 @@
- build/cmake/lib/CMakeLists.txt | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
-
 diff --git a/build/cmake/lib/CMakeLists.txt b/build/cmake/lib/CMakeLists.txt
 index 088c8760..a63b5c81 100644
 --- a/build/cmake/lib/CMakeLists.txt
 +++ b/build/cmake/lib/CMakeLists.txt
-@@ -121,7 +121,7 @@ if (ZSTD_BUILD_SHARED)
-     set_target_properties(
+@@ -122,5 +122,5 @@ if (ZSTD_BUILD_SHARED)
              libzstd_shared
              PROPERTIES
 -            OUTPUT_NAME zstd
 +            OUTPUT_NAME libzstd
              VERSION ${zstd_VERSION_MAJOR}.${zstd_VERSION_MINOR}.${zstd_VERSION_PATCH}
              SOVERSION ${zstd_VERSION_MAJOR})
- endif ()
-@@ -131,7 +131,7 @@ if (ZSTD_BUILD_STATIC)
-             libzstd_static
+@@ -132,5 +132,5 @@ if (ZSTD_BUILD_STATIC)
              PROPERTIES
              POSITION_INDEPENDENT_CODE On
 -            OUTPUT_NAME ${STATIC_LIBRARY_BASE_NAME})
 +            OUTPUT_NAME libzstd_a)
  endif ()
  
- if (UNIX OR MINGW)


### PR DESCRIPTION
See the individual commit messages for more details.

TL;DR: the first commit fixes the artifacts, so that the package can be shipped as built. The other two commits fix incompatibilities with newer zstd versions, and as such are an alternative to #28.

PS: test builds at https://github.com/winlibs/winlib-builder/actions/workflows/libzstd.yml.