### PR TITLE
Add CMake based cURL builder

### DIFF
--- a/.github/workflows/curl_cmake.yml
+++ b/.github/workflows/curl_cmake.yml
@@ -1,0 +1,74 @@
+name: Build curl_cmake
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: curl tag to build
+        required: true
+      php:
+        description: PHP version to build for
+        required: true
+      stability:
+        description: the series stability
+        required: false
+        default: 'staging'
+defaults:
+  run:
+    shell: cmd
+jobs:
+  build:
+    strategy:
+      matrix:
+          arch: [x64, x86]
+    runs-on: windows-2022
+    steps:
+      - name: Checkout winlib-builder
+        uses: actions/checkout@v4
+        with:
+          path: winlib-builder
+      - name: Checkout curl
+        uses: actions/checkout@v4
+        with:
+          path: curl
+          repository: winlibs/curl
+          ref: ${{github.event.inputs.version}}
+      - name: Patch curl
+        run: cd curl && git apply --ignore-whitespace ..\winlib-builder\patches\curl.patch
+      - name: Compute virtual inputs
+        id: virtuals
+        run: powershell winlib-builder/scripts/compute-virtuals -version ${{github.event.inputs.php}} -arch ${{matrix.arch}}
+      - name: Fetch dependencies
+        run: powershell winlib-builder/scripts/fetch-deps -lib curl -version ${{github.event.inputs.php}} -vs ${{steps.virtuals.outputs.vs}} -arch ${{matrix.arch}} -stability ${{github.event.inputs.stability}}
+      - name: Setup MSVC development environment
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{matrix.arch}}
+          toolset: ${{steps.virtuals.outputs.toolset}}
+      - name: Configure curl
+        run: |
+          cd curl
+          cmake -G "Visual Studio 17 2022" -A ${{steps.virtuals.outputs.msarch}}^
+            -T ${{steps.virtuals.outputs.msts}} -DCMAKE_SYSTEM_VERSION=${{steps.virtuals.outputs.winsdk}}^
+            -DBUILD_SHARED_LIBS=OFF -DBUILD_STATIC_LIBS=ON -DBUILD_STATIC_CURL=ON -DSHARE_LIB_OBJECT=OFF -DBUILD_LIBCURL_DOCS=OFF^
+            -DCURL_USE_LIBPSL=OFF^
+            -DCURL_USE_OPENSSL=ON -DOPENSSL_ROOT_DIR:PATH=%GITHUB_WORKSPACE%\deps^
+            -DZLIB_LIBRARY:PATH=%GITHUB_WORKSPACE%\deps\lib\zlib_a.lib -DZLIB_INCLUDE_DIR:PATH=%GITHUB_WORKSPACE%\deps\include^
+            -DNGHTTP2_INCLUDE_DIR:PATH=%GITHUB_WORKSPACE%\deps\include -DNGHTTP2_LIBRARY:PATH=%GITHUB_WORKSPACE%\deps\lib\nghttp2.lib^
+            -DLIBSSH2_INCLUDE_DIR:PATH=%GITHUB_WORKSPACE%\deps\include\libssh2 -DLIBSSH2_LIBRARY:PATH=%GITHUB_WORKSPACE%\deps\lib\libssh2.lib^
+            .
+      - name: Build curl
+        run: cd curl && cmake --build . --config RelWithDebInfo
+      - name: Install curl
+        run: |
+          cd curl
+          cmake --install . --config RelWithDebInfo --prefix %GITHUB_WORKSPACE%\install
+          copy src\RelWithDebInfo\curl.pdb %GITHUB_WORKSPACE%\install\bin\*
+          copy lib\RelWithDebInfo\libcurl_a.pdb %GITHUB_WORKSPACE%\install\lib\*
+          del %GITHUB_WORKSPACE%\install\bin\curl-config
+          del %GITHUB_WORKSPACE%\install\bin\mk-ca-bundle.pl
+          rd /s /q %GITHUB_WORKSPACE%\install\share
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{github.event.inputs.version}}-${{steps.virtuals.outputs.vs}}-${{matrix.arch}}
+          path: install

--- a/patches/curl.patch
+++ b/patches/curl.patch
@@ -1,0 +1,16 @@
+ lib/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
+index c1863b0de..613f2fa5b 100644
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -22,7 +22,7 @@
+ #
+ ###########################################################################
+ set(LIB_NAME "libcurl")
+-set(LIBCURL_OUTPUT_NAME "libcurl" CACHE STRING "Basename of the curl library")
++set(LIBCURL_OUTPUT_NAME "libcurl_a" CACHE STRING "Basename of the curl library")
+ add_definitions("-DBUILDING_LIBCURL")
+ 
+ configure_file("curl_config.h.cmake" "${CMAKE_CURRENT_BINARY_DIR}/curl_config.h")


### PR DESCRIPTION
The "classic" Windows build chain (winbuilder) is formally deprecated as of cURL 8.12.0, and scheduled for removal in September 2025.

Therefore we prepare for builds using the CMake toolchain.

---

The obvious benefit is that we are able to build future releases without having to maintain the winbuilder ourselves; besides that, we can use some options (such as building with brotli and zstd) which are not supported by winbuilder.

A downside is that we may get slightly different builds, and maybe more importantly, that we now need to patch cURL to be able to stick to our naming conventions. I've solved this for now by adding a patch file, but this will not work for cURL < 8.11.0, and easily might break in the future.

A test build (untested) is available at https://github.com/cmb69/winlib-builder/actions/runs/13167998113. Note that I included the pkgconfig and cmake files, although they might be useless (at least the pkgconfig file is).

TODO:
- be more conservative (check that we have the "same" build as before; especially `USE_IDN`, `ENABLE_IPV6` and `CURL_DISABLE_MQTT` should be checked)
- be more defensive (possibly, we should explicitly disable some options regarding dependencies, so we don't inadvertantly use them)
- be more farsighted (we should actually set `CURL_USE_PKGCONFIG=ON`, but that won't work for now, since the dependencies have no .pc files, and there are [issues using pkg-config with CMake on Windows](https://gitlab.kitware.com/cmake/cmake/-/issues/23641))
